### PR TITLE
Fix format string that requires two arguments but only gets one

### DIFF
--- a/diana-registrydec.py
+++ b/diana-registrydec.py
@@ -41,7 +41,7 @@ dictAllGroups = {**dictNormalGroups, **dictDomainGroups, **dictBuiltinGroups}
 
 def checkParameters(options, args):
     if options.live:
-        for x in ['SYSTEM', 'SECURITY', 'SOFTWARE', 'SAM']: os.system(r'REG.EXE SAVE HKLM\{} {} /Y >nul 2>&1'.format(x))
+        for x in ['SYSTEM', 'SECURITY', 'SOFTWARE', 'SAM']: os.system(r'REG.EXE SAVE HKLM\{} {} /Y >nul 2>&1'.format(x, x))
         sSOFTWAREhive = 'SOFTWARE'
         sSECURITYhive = 'SECURITY'
         sSYSTEMhive = 'SYSTEM'


### PR DESCRIPTION
format string for "reg save" was changes from f-string to .format() before but only one argument was added