### PR TITLE
Decrypt Chrome ABE encryption using SYSTEM dpapi, USER dpapi and static AES-GCM/ChaCha20-Poly1305

### DIFF
--- a/diana-browserdec.py
+++ b/diana-browserdec.py
@@ -82,6 +82,7 @@ def parseArgs():
     return oArgs
 
 def parseLocalState(sLocalStateFile):
+    oABESystemBlob = None
     try:
         with open(sLocalStateFile, 'r') as oFile: lLocalState = json.loads(oFile.read())
         oFile.close()


### PR DESCRIPTION
Google Chrome uses app-bound encryption to protect logins/cookies with additional steps (SYSTEM dpapi, USER dpapi and static symmetric encryption), see the [Google Blog entry](https://security.googleblog.com/2024/07/improving-security-of-chrome-cookies-on.html). So far, diana-browserdec.py only decrypts cookies of other Chromium-based browsers that are not using the additional static encryption:

- Chrome 127+ uses AES-GCM
- Chrome 133+ uses ChaCha20-Poly1305

The PR heavily relies on the work at [runassu/chrom_v20_decryption](https://github.com/runassu/chrome_v20_decryption)
